### PR TITLE
merge_with raises err on no inputs

### DIFF
--- a/toolz/curried.py
+++ b/toolz/curried.py
@@ -37,7 +37,7 @@ def nargs(f):
 
 
 def should_curry(f):
-    do_curry = set((toolz.map, toolz.filter))
+    do_curry = set((toolz.map, toolz.filter, toolz.merge_with))
     return (callable(f) and nargs(f) and nargs(f) > 1
             or f in do_curry)
 

--- a/toolz/dicttoolz/core.py
+++ b/toolz/dicttoolz/core.py
@@ -36,6 +36,9 @@ def merge_with(fn, *dicts):
     See Also:
         merge
     """
+    if len(dicts) == 0:
+        raise TypeError("No arguments")
+
     if len(dicts) == 1 and not isinstance(dicts[0], dict):
         dicts = dicts[0]
 


### PR DESCRIPTION
This enables `merge_with` to operate cleanly with `curry` but removes the base case of `merge_with(func) == {}`
