### PR TITLE
Compose does more work on __init__ to do less on call.

### DIFF
--- a/toolz/functoolz.py
+++ b/toolz/functoolz.py
@@ -362,7 +362,7 @@ class Compose(object):
 
     def __call__(self, *args, **kwargs):
         ret = self.funcs[0](*args, **kwargs)
-        for f in self.funcs[:-1]:
+        for f in self.funcs[1:]:
             ret = f(ret)
         return ret
 


### PR DESCRIPTION
The change in this pull makes compose more efficient.

I noticed compose in the profile of an app which prompted me to look at the implementation.

The original timing:

```
$ python2 -m timeit -s 'from toolz.functoolz import compose, identity; f = compose(*([identity]*10))' 'f(10)'
100000 loops, best of 3: 3.01 usec per loop
```

With the change:

```
$ python2 -m timeit -s 'from toolz.functoolz import compose, identity; f = compose(*([identity]*10))' 'f(10)'
1000000 loops, best of 3: 1.59 usec per loop
```
